### PR TITLE
Provide build flag to disable compilation of yang dependent interfaces

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -26,10 +26,8 @@ common_libswsscommon_la_SOURCES = \
     common/configdb.cpp              \
     common/dbconnector.cpp           \
     common/dbinterface.cpp           \
-    common/defaultvalueprovider.cpp  \
     common/sonicv2connector.cpp      \
     common/table.cpp                 \
-    common/decoratortable.cpp        \
     common/json.cpp                  \
     common/producertable.cpp         \
     common/producerstatetable.cpp    \
@@ -60,7 +58,6 @@ common_libswsscommon_la_SOURCES = \
     common/exec.cpp                  \
     common/saiaclschema.cpp          \
     common/subscriberstatetable.cpp  \
-    common/decoratorsubscriberstatetable.cpp \
     common/timestamp.cpp             \
     common/warm_restart.cpp          \
     common/luatable.cpp              \
@@ -70,13 +67,22 @@ common_libswsscommon_la_SOURCES = \
     common/profileprovider.cpp       \
     common/zmqclient.cpp             \
     common/zmqserver.cpp             \
-    common/asyncdbupdater.cpp   \
+    common/asyncdbupdater.cpp        \
     common/redis_table_waiter.cpp
 
 common_libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 common_libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)
-common_libswsscommon_la_LIBADD = -lpthread $(LIBNL_LIBS) $(CODE_COVERAGE_LIBS) -lzmq -lboost_serialization -luuid -lyang
+common_libswsscommon_la_LIBADD = -lpthread $(LIBNL_LIBS) $(CODE_COVERAGE_LIBS) -lzmq -lboost_serialization -luuid
 common_libswsscommon_la_LDFLAGS = -Wl,-z,now $(LDFLAGS)
+
+if YANGMODS
+common_libswsscommon_la_SOURCES += \
+    common/defaultvalueprovider.cpp  \
+    common/decoratortable.cpp        \
+    common/decoratorsubscriberstatetable.cpp
+
+common_libswsscommon_la_LIBADD += -lyang
+endif
 
 common_swssloglevel_SOURCES =  \
 	common/loglevel.cpp        \

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -255,6 +255,12 @@ protected:
                     ret.setdefault(table_name, {})[self.deserialize_key(row)] = entry
             return ret
 
+%}
+#endif
+
+#if defined(SWIG) && defined(SWIGPYTHON) && defined(ENABLE_YANG_MODULES)
+%pythoncode %{
+
     class YangDefaultDecorator(object):
         def __init__(self, config_db_connector):
             self.connector = config_db_connector

--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,16 @@ AC_ARG_ENABLE(python2,
 	no)  python2=false ;;
 	*) AC_MSG_ERROR(bad value ${enableval} for --enable-python2) ;;
 esac],[python2=true])
+AC_ARG_ENABLE(yang-modules,
+[  --enable-yang-modules   Generate classes that depend on libyang],
+[case "${enableval}" in
+	yes) yang-modules=true ;;
+	no)  yang-modules=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-yang-modules) ;;
+esac],[yang-modules=true])
 AM_CONDITIONAL(DEBUG, test x$debug = xtrue)
 AM_CONDITIONAL(PYTHON2, test x$python2 = xtrue)
+AM_CONDITIONAL(YANGMODS, test x$yang-modules = xtrue)
 if test x$CONFIGURED_ARCH = xarmhf && test x$CROSS_BUILD_ENVIRON = xy; then
 	AM_CONDITIONAL(ARCH64, false)
 else

--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,11 @@ else
 CONFIGURE_ARGS += --disable-python2
 endif
 
+# Skip compiling classes that depend on libyang
+ifneq (,$(filter noyangmod,$(DEB_BUILD_PROFILES)))
+CONFIGURE_ARGS += --disable-yang-modules
+endif
+
 # main packaging script
 %:
 	dh $@

--- a/pyext/py2/Makefile.am
+++ b/pyext/py2/Makefile.am
@@ -6,6 +6,11 @@ pyext_py2__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(P
 pyext_py2__swsscommon_la_LDFLAGS = -module -Wl,-z,now
 pyext_py2__swsscommon_la_LIBADD = common/libswsscommon.la -lpython$(PYTHON_VERSION)
 
+if YANGMODS
+SWIG_FLAG += -DENABLE_YANG_MODULES
+pyext_py2__swsscommon_la_CPPFLAGS += -DENABLE_YANG_MODULES
+endif
+
 pyext/py2/swsscommon_wrap.cpp: $(SWIG_SOURCES)
 	$(SWIG) $(SWIG_FLAG) -Icommon -o $@ $<
 

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -6,6 +6,11 @@ pyext_py3__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(P
 pyext_py3__swsscommon_la_LDFLAGS = -module -Wl,-z,now
 pyext_py3__swsscommon_la_LIBADD = common/libswsscommon.la $(PYTHON3_BLDLIBRARY)
 
+if YANGMODS
+SWIG_FLAG += -DENABLE_YANG_MODULES
+pyext_py3__swsscommon_la_CPPFLAGS += -DENABLE_YANG_MODULES
+endif
+
 pyext/py3/swsscommon_wrap.cpp: $(SWIG_SOURCES)
 	$(SWIG) $(SWIG_FLAG) -Icommon -o $@ $<
 

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -20,14 +20,12 @@
 #include "schema.h"
 #include "dbconnector.h"
 #include "dbinterface.h"
-#include "defaultvalueprovider.h"
 #include "sonicv2connector.h"
 #include "pubsub.h"
 #include "select.h"
 #include "selectable.h"
 #include "rediscommand.h"
 #include "table.h"
-#include "decoratortable.h"
 #include "countertable.h"
 #include "redispipeline.h"
 #include "redisreply.h"
@@ -40,7 +38,11 @@
 #include "profileprovider.h"
 #include "consumertable.h"
 #include "subscriberstatetable.h"
+#ifdef ENABLE_YANG_MODULES
+#include "decoratortable.h"
+#include "defaultvalueprovider.h"
 #include "decoratorsubscriberstatetable.h"
+#endif
 #include "notificationconsumer.h"
 #include "notificationproducer.h"
 #include "warm_restart.h"
@@ -251,7 +253,9 @@ T castSelectableObj(swss::Selectable *temp)
 
 %include "schema.h"
 %include "dbconnector.h"
+#ifdef ENABLE_YANG_MODULES
 %include "defaultvalueprovider.h"
+#endif
 %include "sonicv2connector.h"
 %include "pubsub.h"
 %include "profileprovider.h"
@@ -278,7 +282,9 @@ T castSelectableObj(swss::Selectable *temp)
 %apply std::vector<std::pair<std::string, std::string>>& OUTPUT {std::vector<std::pair<std::string, std::string>> &ovalues};
 %apply std::string& OUTPUT {std::string &value};
 %include "table.h"
+#ifdef ENABLE_YANG_MODULES
 %include "decoratortable.h"
+#endif 
 %clear std::vector<std::string> &keys;
 %clear std::vector<std::string> &ops;
 %clear std::vector<std::vector<std::pair<std::string, std::string>>> &fvss;
@@ -318,7 +324,9 @@ T castSelectableObj(swss::Selectable *temp)
 %include "consumertable.h"
 %include "consumerstatetable.h"
 %include "subscriberstatetable.h"
+#ifdef ENABLE_YANG_MODULES
 %include "decoratorsubscriberstatetable.h"
+#endif
 
 %apply std::string& OUTPUT {std::string &op};
 %apply std::string& OUTPUT {std::string &data};

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,6 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/countertable_ut.cpp         \
                       tests/timer_ut.cpp                \
                       tests/cli_ut.cpp                  \
-                      tests/defaultvalueprovider_ut.cpp \
                       tests/events_common_ut.cpp        \
                       tests/events_service_ut.cpp       \
                       tests/events_ut.cpp               \
@@ -48,3 +47,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
 tests_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)
 tests_tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS) -fno-access-control
 tests_tests_LDADD = $(LDADD_GTEST) -lpthread common/libswsscommon.la $(LIBNL_LIBS) $(CODE_COVERAGE_LIBS) sonic-db-cli/libsonicdbcli.la -lzmq -luuid -lboost_serialization
+
+if YANGMODS
+tests_tests_SOURCES += tests/defaultvalueprovider_ut.cpp
+endif


### PR DESCRIPTION
#### Why i did it
libswsscommon depends on libyang deb. libyang is deprecated in bookworm. This wouldn't be a problem for buildimage because libyang is compiled from source in buildimage. 

However, this is causing a problem in upgrading one of our app-extensions to bookworm. This app-extension is built separately and not part of buildimage infra. 

Thus provide a build flag to disable compilation of libyang dependent interfaces such as DecoratorTable etc. Please note, there is no change in the default behavior

#### How did i verify
<Build with dep profile>

```
vkarri@6c5cda5d64fa:/sonic/src/sonic-swss-common$ debuild -b -us -uc -Pnopython2,noyangmod 
vkarri@6c5cda5d64fa:/sonic/src$ sudo dpkg -i libswsscommon_1.0.0_amd64.deb vkarri@6c5cda5d64fa:/sonic/src$ sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb 
vkarri@6c5cda5d64fa:/sonic/src$ python3 -c "from swsscommon.swsscommon import DecoratorSubscriberStateTable" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'DecoratorSubscriberStateTable' from 'swsscommon.swsscommon' (/usr/lib/python3/dist-packages/swsscommon/swsscommon.py) 
vkarri@6c5cda5d64fa:/sonic/src$ python3 -c "from swsscommon.swsscommon import DecoratorTable" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'DecoratorTable' from 'swsscommon.swsscommon' (/usr/lib/python3/dist-packages/swsscommon/swsscommon.py) 
vkarri@6c5cda5d64fa:/sonic/src$ python3 -c "from swsscommon.swsscommon import YangDefaultDecorator" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'YangDefaultDecorator' from 'swsscommon.swsscommon' (/usr/lib/python3/dist-packages/swsscommon/swsscommon.py) 

vkarri@6c5cda5d64fa:/sonic/src$ python3 -c "from swsscommon.swsscommon import SubscriberStateTable, ProducerStateTable, Table, DBConnector"
```

**Default Behavior:**

```
vkarri@6c5cda5d64fa:/sonic$ make -f slave.mk target/debs/bookworm/python3-swsscommon_1.0.0_amd64.deb-install
vkarri@6c5cda5d64fa:/sonic$ python3 -c "from swsscommon.swsscommon import DecoratorSubscriberStateTable, DecoratorTable, YangDefaultDecorator"
vkarri@6c5cda5d64fa:/sonic$
```
